### PR TITLE
Added template for BioSchemas Tool annotation

### DIFF
--- a/layouts/_bioc_views_package_detail.html
+++ b/layouts/_bioc_views_package_detail.html
@@ -2,6 +2,19 @@
 
   <% if current? @package %>
 
+<script type="application/ld+json">
+{
+  "@context":"http://schema.org/",
+  "@type":"Tool",
+  "name":"<%=@package[:Package]%>",
+  "description":"<%= @package[:Description]%>",
+  "url":[
+    "<%=get_short_url(@package)%>"
+  ],
+  "softwareVersion":"<%= @package[:Version]%>"
+}
+</script>
+
     <% tr = TableRower.new %>
 
     <table border="0">


### PR DESCRIPTION
Uses [BioSchemas](https://github.com/BioSchemas/specifications) Tool 0.3-DRAFT (21 November 2018), see http://bioschemas.org/devSpecs/Tool/.

I have tested the output with https://search.google.com/structured-data/testing-tool and example data (for the [RMassBank](http://bioconductor.org/packages/release/bioc/html/RMassBank.html) package) can be found in this gist: https://gist.github.com/egonw/8347966585990579260f3e7e59d3954f

The BioSchemas JSON-LD is embedded in a `<script>` element, and ignored by everything except that for looking for scripts. BioSchemas is an ELIXIR Europe-supported schema.org extension (Google, Bing, and friend) for finding metadata.

The patch is simple and clean, but I would not mind seeing it run on a dev version of the website first, for testing the deployment too. Basically, the way to do this would be to open the https://search.google.com/structured-data/testing-tool (again) and pass the URL to the live HTML page with this embedded JSON-LS. The output should look like this:

![image](https://user-images.githubusercontent.com/26721/55386211-4cb0f480-552f-11e9-85ae-ead7e99425e5.png)

The warning that Tool is not recognized is expected (in the BioSchemas world).